### PR TITLE
fix: `span` tag in `a` would lose pointer cursor

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -32,7 +32,7 @@ font-weight: 600;
     box-sizing: border-box;
 }
 
-:not(input):not(select):not(textarea) {
+:not(input):not(select):not(textarea):not(a *) {
     cursor:default;
 }
 


### PR DESCRIPTION
Reproduced in both Chrome and Firefox. Fixed.

![image](https://user-images.githubusercontent.com/20502130/118312433-ea0aef00-b523-11eb-9e87-768cb65a5f7c.png)
![image](https://user-images.githubusercontent.com/20502130/118312464-f8f1a180-b523-11eb-9f24-06324ad16e6f.png)
